### PR TITLE
Live price update with BitcoinAverage.com API key

### DIFF
--- a/Lnd_wrapper.php
+++ b/Lnd_wrapper.php
@@ -88,10 +88,11 @@ class LndWrapper
     /**
      * Set endpoint credentials
      */
-    public function setCredentials ( $endpoint , $macaroonHex , $tlsPath){
+    public function setCredentials ( $endpoint, $macaroonHex, $tlsPath, $btcavgAPI ){
         $this->endpoint = $endpoint;
         $this->macaroonHex = $macaroonHex;
         $this->tlsPath = $tlsPath;
+        $this->btcavgAPI = $btcavgAPI;
     }
 
     public function setCoin ( $coin ){
@@ -140,13 +141,17 @@ class LndWrapper
         }
         $tickerUrl = "https://apiv2.bitcoinaverage.com/indices/global/ticker/" . $ticker;
         $aHTTP = array(
-          'http' =>
-            array(
-            'method'  => 'GET',
-              )
+          'http' => array(
+            'method'  => 'GET'
+          )
         );
-        $content = file_get_contents($tickerUrl, false);
 
+        // Authenticates with bitcoinaverage.com API key, if available
+        if($btcavg_api_key = $this->btcavgAPI) {
+            $aHTTP['http']['header'] = 'x-ba-key: ' . $btcavg_api_key;
+        }
+        $context = stream_context_create($aHTTP);
+        $content = file_get_contents($tickerUrl, false, $context);
         return json_decode($content, true)['ask'];
     }
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ using [LND](https://github.com/lightningnetwork/lnd).
 
 Requires PHP >= 5.6 and the `php-curl` and `php-gd` extensions.
 
-1. Setup a [LND] node (https://github.com/lightningnetwork/lnd), Raspberry Pi set-up (https://stadicus.github.io/RaspiBolt/)
+1. Setup a [LND] node (https://github.com/lightningnetwork/lnd), 
+   Raspberry Pi set-up (https://stadicus.github.io/RaspiBolt/)
 
 2. Get the Node server IP and macaroon key
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Requires PHP >= 5.6 and the `php-curl` and `php-gd` extensions.
 
 5. Add LND tls.cert to plugin-folder/tls or input the exact path on plugin settings.
 
+6. Add BitcoinAverage.com API public key to authenticate live price reliably (https://pro.bitcoinaverage.com/pages/auth/api-keys)
+
 
 The payment option should now be available in your checkout page.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ using [LND](https://github.com/lightningnetwork/lnd).
 
 Requires PHP >= 5.6 and the `php-curl` and `php-gd` extensions.
 
-1. Setup a [LND] node (https://github.com/lightningnetwork/lnd).
+1. Setup a [LND] node (https://github.com/lightningnetwork/lnd), Raspberry Pi set-up (https://stadicus.github.io/RaspiBolt/)
 
 2. Get the Node server IP and macaroon key
 

--- a/woocommerce-gateway-lightning.php
+++ b/woocommerce-gateway-lightning.php
@@ -116,8 +116,14 @@ if (!function_exists('init_wc_lightning')) {
             'description' => __('Put your LND SSL certificate path.', 'lightning'),
             'default'     => $tlsPath,
             'desc_tip'    => true,
+          ),
+          'btcavg_api' => array(
+            'title'       => __('BitcoinAverage.com API key', 'lightning'),
+            'type'        => 'textarea',
+            'description' => __('Enter your BitcoinAverage.com public API key for authentication.', 'lightning'),
+            'default'     => '',
+            'desc_tip'    => true,
           )
-          
         );
       }
 

--- a/woocommerce-gateway-lightning.php
+++ b/woocommerce-gateway-lightning.php
@@ -219,8 +219,9 @@ if (!function_exists('init_wc_lightning')) {
         }
         
         if ($callResponse->settled) {
+          $settle_date = $callResponse->settle_date;
+          $order->add_order_note( 'Lightning Payment received on '. date( 'Y-m-d H:i:s', $settle_date ) .' UTC ('. $settle_date .')' );
           $order->payment_complete();
-          $order->add_order_note('Lightning Payment received on ' . $invoiceRep->settle_date);
           status_header(200);
           wp_send_json(true);
           return;


### PR DESCRIPTION
I was testing my WooCommerce store's implementation and kept getting an error: "Error: EOF."  I enabled WP_DEBUG and found that the HTTP request to apiv2.bitcoinaverage.com was failing frequently "HTTP/1.1 403 Forbidden."

Upon review of the BitcoinAverage.com documentation (https://apiv2.bitcoinaverage.com/#authentication), I found that requests should now include a header for 'x-ba-key' with the public API key.  That said, I was able to force a response, after 3+ errors repeatedly clicking the "Proceed to Lightning Payment" button, but that's hardly ideal.

I created a free account on BitcoinAverage.com (https://pro.bitcoinaverage.com/pages/auth/register), and my updates seem to be working well.  After creating a free account limited to 5000 requests/month, I can access my API public key (https://pro.bitcoinaverage.com/pages/auth/api-keys) to include in the payment method's settings.

Any feedback is welcome, and big thanks to @joaodealmeida for this great plugin!